### PR TITLE
bugfix/Fix range check error on StartPingTimer

### DIFF
--- a/Tina4WebSocketClient.pas
+++ b/Tina4WebSocketClient.pas
@@ -1366,7 +1366,13 @@ begin
         // Ping cadence — emit a ping once per FPingInterval. We only
         // arm a new FLastPingSent when there isn't one already (so
         // back-to-back pings don't clobber the RTT measurement).
-        ElapsedSincePing := MilliSecondsBetween(Now, FLastPingSent);
+        // FLastPingSent = 0 is the "no ping in flight" sentinel; TDateTime(0)
+        // is 1899, so MilliSecondsBetween against it overflows Integer — only
+        // compute the elapsed time when a ping is actually outstanding.
+        if FLastPingSent = 0 then
+          ElapsedSincePing := 0
+        else
+          ElapsedSincePing := MilliSecondsBetween(Now, FLastPingSent);
         if (FLastPingSent = 0) or (ElapsedSincePing >= FPingInterval) then
         begin
           try


### PR DESCRIPTION
Fix range check error after WebSocket connection

A range check error occurs after establishing a WebSocket connection due to an invalid timestamp being used in MilliSecondsBetween. This error can be reproduced in a Windows build when using the component. 